### PR TITLE
Added frame names to ndi_msg and rigidPoseBroadcaster

### DIFF
--- a/ndi_controllers/rigid_pose_broadcaster/src/rigid_pose_broadcaster.cpp
+++ b/ndi_controllers/rigid_pose_broadcaster/src/rigid_pose_broadcaster.cpp
@@ -159,12 +159,14 @@ RigidPoseBroadcaster::update(const rclcpp::Time & time, const rclcpp::Duration &
         rigidPoseMsg.poses.push_back(tempPose);
         rigidPoseMsg.ids.push_back(sensorID);
         rigidPoseMsg.inbound.push_back(true);
+        rigidPoseMsg.frames.push_back(sensorName);
       }
       else
       {
         rigidPoseMsg.poses.push_back(tempPose);
         rigidPoseMsg.ids.push_back(sensorID);
         rigidPoseMsg.inbound.push_back(false);
+        rigidPoseMsg.frames.push_back(sensorName);
       }
     }
     realtime_rigid_pose_publisher_->unlockAndPublish();

--- a/ndi_msgs/msg/RigidArray.msg
+++ b/ndi_msgs/msg/RigidArray.msg
@@ -4,8 +4,11 @@
 # Time of sensor data acquisition, coordinate frame ID.
 std_msgs/Header header
 
-#Array of point IDs.
+#Array of tracker IDs.
 int32[] ids
+
+#Array of tracker names.
+string[] frames
 
 #If tracker is inbound measurement pyramid
 bool[] inbound


### PR DESCRIPTION
Added frame names to `ndi_msgs::msg::RigidArray` to facilitate message translation to `tf2` trees.